### PR TITLE
in empiricalBayes the alphanumeric order of groups matters

### DIFF
--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -62,6 +62,8 @@ if(length(unique(groups))==1 | length(unique(groups))>=3) {
 # Empirical Bayes
 if(meth=="empiricalBayes") {
 	library(limma)
+	#
+	groups<-groups[c(which(groups==sort(unique(groups))[1]),which(groups==sort(unique(groups))[2]))]
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))
 	} else {

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -62,7 +62,9 @@ if(length(unique(groups))==1 | length(unique(groups))>=3) {
 # Empirical Bayes
 if(meth=="empiricalBayes") {
 	library(limma)
-	#
+	#sort of groups should not matter (like in other methods)
+	#  the calls to as.factor and factor makes the lexical group order relevant
+	#  to avoid this we reorder the groups to be always in alphanumeric order
 	groups<-groups[c(which(groups==sort(unique(groups))[1]),which(groups==sort(unique(groups))[2]))]
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))


### PR DESCRIPTION
For the statistical two groups test (stat-two-groups.R) the alphanumeric order of the groups does not matter for all methods except empiricalBayes.
That means, the fold-changes do not change sign, when you change the order of the groups in the phenodata. The same holds for calculate-fold-change.R

Here is a code example which demonstrates the behaviour of empiricalBayes:

```
library(multtest)
library(limma)
adj.method<-"BH"
dat2<-matrix(c(1,2,1,2,2,1,2,1,8,7,8,9,8,7,8,9),ncol=4)
dat2

groups<-c(2,2,1,1)
pairing <- "EMPTY"
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC
data.frame(dat2, p.adjusted=round(p, digits=6), FC=M)

groups<-c(1,1,2,2)
pairing <- "EMPTY"
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC
data.frame(dat2, p.adjusted=round(p, digits=6), FC=M)
```

As you can see the FC sign changes with the order of the group definition. This behaviour is in contrast to the other methods and to the tool in calculate-fold-change.R

All other methods can rely just on the function unique for the groups and need no sorting.
In empiricalBayes the use of as.factor and factor implicitly introduce the order relevance of the results.

To the typical chipster user this behaviour can be surprising and can lead to misinterpretations.

To make empiricalBayes behave coherently the new line brings the groups into alphanumeric order before the calls to factor and as.factor.

