### PR TITLE
alphanumeric order of groups and sign of the fold change

### DIFF
--- a/tools/microarray/R/calculate-fold-change.R
+++ b/tools/microarray/R/calculate-fold-change.R
@@ -54,7 +54,7 @@ columnnames<-c()
 dat3<-matrix(nrow=nrow(dat2), ncol=length(unique(groups)), NA)
 #for(i in 1:length(unique(groups))) {
 index=1
-for( i in unique(groups) ) {
+for( i in sort(unique(groups)) ) {
 	dat3[,index]<-rowSums(data.frame(dat2[,which(groups==i)]))/ncol(data.frame(dat2[,which(groups==i)]))
 	columnnames<-c(columnnames, paste("group", i, sep=""))
 	index=index+1

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -62,6 +62,8 @@ if(length(unique(groups))==1 | length(unique(groups))>=3) {
 # Empirical Bayes
 if(meth=="empiricalBayes") {
 	library(limma)
+	#
+	groups<-groups[c(which(groups==sort(unique(groups))[1]),which(groups==sort(unique(groups))[2]))]
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))
 	} else {

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -65,10 +65,6 @@ if(meth=="empiricalBayes") {
 	#sort of groups should not matter (like in other methods)
 	#  the calls to as.factor and factor makes the lexical group order relevant
 	#  to avoid this we reorder the groups to be always in alphanumeric order
-	gsorted=groups
-	gsorted[which(groups==unique(groups)[1])]=sort(unique(groups))[1]
-	gsorted[which(groups==unique(groups)[2])]=sort(unique(groups))[2]
-	groups=gsorted
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))
 	} else {
@@ -95,10 +91,10 @@ if(meth=="empiricalBayes") {
 
 if(meth=="RankProd") {
 	library(RankProd)
+
+	dat2.1 <-dat2[,which(groups==sort(unique(groups))[1])]
+	dat2.2 <-dat2[,which(groups==sort(unique(groups))[2])]
 	
-	dat2.1 <-dat2[,groups==unique(groups)[1]]
-	dat2.2 <-dat2[,groups==unique(groups)[2]]
-			
 	if(pairing =="EMPTY") {
 		group_vec <- c(rep(0, ncol(dat2.1)), rep(1, ncol(dat2.1)));
 		dat.rp <- cbind(dat2.1, dat2.2);
@@ -127,7 +123,7 @@ if(meth=="RankProd") {
 		dat2.2 <- dat2.2[,match(pairs.1, pairs.2)]
 		
 		if(ncol(dat2.1) != ncol(dat2.2)) { stop("Paired RankProd error: matrices differn in column number")}
-		dat.rp <- dat2.1 - dat2.2;
+		dat.rp <- dat2.2 - dat2.1;
 		group_vec <- rep(0, ncol(dat.rp));
 
 		rp.fold.change <- apply(dat.rp, 1, mean, na.rm=T)

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -102,7 +102,7 @@ if(meth=="RankProd") {
 	if(pairing =="EMPTY") {
 		group_vec <- c(rep(0, ncol(dat2.1)), rep(1, ncol(dat2.1)));
 		dat.rp <- cbind(dat2.1, dat2.2);
-		rp.fold.change <- apply(dat2.1, 1, mean, na.rm=T) - apply(dat2.2, 1, mean, na.rm=T)
+		rp.fold.change <- apply(dat2.2, 1, mean, na.rm=T) - apply(dat2.1, 1, mean, na.rm=T)
 	} else {
 		pairs.1 <-pairs[groups==unique(groups)[1]]
 		pairs.2 <-pairs[groups==unique(groups)[2]]

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -62,9 +62,6 @@ if(length(unique(groups))==1 | length(unique(groups))>=3) {
 # Empirical Bayes
 if(meth=="empiricalBayes") {
 	library(limma)
-	#sort of groups should not matter (like in other methods)
-	#  the calls to as.factor and factor makes the lexical group order relevant
-	#  to avoid this we reorder the groups to be always in alphanumeric order
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))
 	} else {

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -65,7 +65,10 @@ if(meth=="empiricalBayes") {
 	#sort of groups should not matter (like in other methods)
 	#  the calls to as.factor and factor makes the lexical group order relevant
 	#  to avoid this we reorder the groups to be always in alphanumeric order
-	groups<-groups[c(which(groups==sort(unique(groups))[1]),which(groups==sort(unique(groups))[2]))]
+	gsorted=groups
+	gsorted[which(groups==unique(groups)[1])]=sort(unique(groups))[1]
+	gsorted[which(groups==unique(groups)[2])]=sort(unique(groups))[2]
+	groups=gsorted
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))
 	} else {

--- a/tools/microarray/R/stat-two-groups.R
+++ b/tools/microarray/R/stat-two-groups.R
@@ -62,7 +62,9 @@ if(length(unique(groups))==1 | length(unique(groups))>=3) {
 # Empirical Bayes
 if(meth=="empiricalBayes") {
 	library(limma)
-	#
+	#sort of groups should not matter (like in other methods)
+	#  the calls to as.factor and factor makes the lexical group order relevant
+	#  to avoid this we reorder the groups to be always in alphanumeric order
 	groups<-groups[c(which(groups==sort(unique(groups))[1]),which(groups==sort(unique(groups))[2]))]
 	if(pairing=="EMPTY") {
 		design<-model.matrix(~as.factor(groups))


### PR DESCRIPTION
My last code example was not clear enough and not complete to clarify the issue.

The issue is ONLY about what happens when you swap the group identifiers in the
phenodata.

> Now, if you swap the sample groups in phenodata (=assign the controls and samples the other way around), this naturally changes the fold changes. 

This is only true for "Empirical Bayes". All other methods do not swap the sign!
I would say, that the second (not changing sign) should be the desired behaviour,
because there is nothing which makes the use of numbers as group identifiers
and the number 1 as the control identifier explicit or as a natural choice.

There are only two methods in stat-two-groups.R which produce a fold change
column. "Empirical Bayes" and "RankProd". They do not behave equal, because
"RankProd" uses only "unique" on the group IDs resulting in not changing sign
when the group IDs are exchanged.

Calculating fold change using the tool "Calculate fold change" in calculate-fold-change.R does change the sign neither.

The following code shows the results for each of the above methods for the fold change. The code lines are those from the original files currently in use:
```
library(multtest)
library(limma)
adj.method<-"BH"
dat2<-matrix(c(1,2,1,2,2,1,2,1,8,7,8,9,8,7,8,9),ncol=4)
dat2
groups<-c(2,2,1,1)

#Empirical Bayes
pairing <- "EMPTY"
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC

#RankProd
dat2.1 <-dat2[,groups==unique(groups)[1]]
dat2.2 <-dat2[,groups==unique(groups)[2]]
rp.fold.change <- apply(dat2.1, 1, mean, na.rm=T) - apply(dat2.2, 1, mean, na.rm=T)

#calculate-fold-change
columnnames<-c()
dat3<-matrix(nrow=nrow(dat2), ncol=length(unique(groups)), NA)
index=1
for( i in unique(groups) ) {
dat3[,index]<-rowSums(data.frame(dat2[,which(groups==i)]))/ncol(data.frame(dat2[,which(groups==i)]))
columnnames<-c(columnnames, paste("group", i, sep=""))
index=index+1
}
FC <- dat3[,2]-dat3[,1]

M
rp.fold.change
FC
```
The result is:
```
> M  #empiricalBayes
[1] -6.5 -5.5 -6.5 -7.5
> rp.fold.change   #RankProd
[1] -6.5 -5.5 -6.5 -7.5
> FC  #calculate-fold-change
[1] 6.5 5.5 6.5 7.5
```
Now we change the group definition by swapping the numbers/identifiers:
```
groups<-c(1,1,2,2)

#Empirical Bayes
pairing <- "EMPTY"
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC

#RankProd
dat2.1 <-dat2[,groups==unique(groups)[1]]
dat2.2 <-dat2[,groups==unique(groups)[2]]
rp.fold.change <- apply(dat2.1, 1, mean, na.rm=T) - apply(dat2.2, 1, mean, na.rm=T)

#calculate-fold-change
columnnames<-c()
dat3<-matrix(nrow=nrow(dat2), ncol=length(unique(groups)), NA)
index=1
for( i in unique(groups) ) {
dat3[,index]<-rowSums(data.frame(dat2[,which(groups==i)]))/ncol(data.frame(dat2[,which(groups==i)]))
columnnames<-c(columnnames, paste("group", i, sep=""))
index=index+1
}
FC <- dat3[,2]-dat3[,1]

M
rp.fold.change
FC
```
The result is:
```
> M  #empiricalBayes
[1] 6.5 5.5 6.5 7.5
> rp.fold.change   #RankProd
[1] -6.5 -5.5 -6.5 -7.5
> FC  #calculate-fold-change
[1] 6.5 5.5 6.5 7.5
```
Empirical Bayes changed the sign, the others do not!

Now the same with the modified code:
```
library(multtest)
library(limma)
adj.method<-"BH"
dat2<-matrix(c(1,2,1,2,2,1,2,1,8,7,8,9,8,7,8,9),ncol=4)
dat2
groups<-c(2,2,1,1)

#Empirical Bayes
pairing <- "EMPTY"
gsorted=groups
gsorted[which(groups==unique(groups)[1])]=sort(unique(groups))[1]
gsorted[which(groups==unique(groups)[2])]=sort(unique(groups))[2]
groups=gsorted
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC

groups<-c(2,2,1,1)
#RankProd
dat2.1 <-dat2[,groups==unique(groups)[1]]
dat2.2 <-dat2[,groups==unique(groups)[2]]
rp.fold.change <- apply(dat2.2, 1, mean, na.rm=T) - apply(dat2.1, 1, mean, na.rm=T)

#calculate-fold-change
columnnames<-c()
dat3<-matrix(nrow=nrow(dat2), ncol=length(unique(groups)), NA)
index=1
for( i in unique(groups) ) {
dat3[,index]<-rowSums(data.frame(dat2[,which(groups==i)]))/ncol(data.frame(dat2[,which(groups==i)]))
columnnames<-c(columnnames, paste("group", i, sep=""))
index=index+1
}
FC <- dat3[,2]-dat3[,1]

M
rp.fold.change
FC
```
The result is:
```
> M  #empiricalBayes
[1] 6.5 5.5 6.5 7.5
> rp.fold.change   #RankProd
[1] 6.5 5.5 6.5 7.5
> FC  #calculate-fold-change
[1] 6.5 5.5 6.5 7.5
```
Swapping groups:
```
groups<-c(1,1,2,2)

#Empirical Bayes
pairing <- "EMPTY"
gsorted=groups
gsorted[which(groups==unique(groups)[1])]=sort(unique(groups))[1]
gsorted[which(groups==unique(groups)[2])]=sort(unique(groups))[2]
groups=gsorted
design<-model.matrix(~as.factor(groups))
fit <- lmFit(dat2, design)
fit <- eBayes(fit)
tab <- toptable(fit, coef=2, number=nrow(fit), adjust.method=adj.method, sort.by="none")
p <- tab$adj.P.Val
M <- tab$logFC

groups<-c(1,1,2,2)
#RankProd
dat2.1 <-dat2[,groups==unique(groups)[1]]
dat2.2 <-dat2[,groups==unique(groups)[2]]
rp.fold.change <- apply(dat2.2, 1, mean, na.rm=T) - apply(dat2.1, 1, mean, na.rm=T)

#calculate-fold-change
columnnames<-c()
dat3<-matrix(nrow=nrow(dat2), ncol=length(unique(groups)), NA)
index=1
for( i in unique(groups) ) {
dat3[,index]<-rowSums(data.frame(dat2[,which(groups==i)]))/ncol(data.frame(dat2[,which(groups==i)]))
columnnames<-c(columnnames, paste("group", i, sep=""))
index=index+1
}
FC <- dat3[,2]-dat3[,1]

M
rp.fold.change
FC
```
The result is:
```
> M  #empiricalBayes
[1] 6.5 5.5 6.5 7.5
> rp.fold.change   #RankProd
[1] 6.5 5.5 6.5 7.5
> FC  #calculate-fold-change
[1] 6.5 5.5 6.5 7.5
```

Coherent!







