### PR TITLE
Chloroplast removal fix: class -> order

### DIFF
--- a/tools/ngs/R/metabarcoding-filter-individual.R
+++ b/tools/ngs/R/metabarcoding-filter-individual.R
@@ -27,9 +27,9 @@ if (type == "species" &&
 		stop("Data set lacks species-level assignments; please choose another level of organization.")
 }
 
-# Remove class Chloroplast
+# Remove order Chloroplast
 if (remove.chloroplast == "yes") {
-	ps <- subset_taxa(ps, Class != "Chloroplast")
+	ps <- subset_taxa(ps, Order != "Chloroplast")
 }
 
 # Remove family Mitochondria


### PR DESCRIPTION
'Chloroplast' is not under class anymore in the latest Silva but under order. Class for chloroplast says now 'Cyanobacteriia'. Changed the taxonomic level in the removal of chloroplasts to fit this change.