### PR TITLE
Fix for NAs in Silva 138.1+DADA2 taxonomy table

### DIFF
--- a/tools/ngs/R/dada-make-phyloseq-object.R
+++ b/tools/ngs/R/dada-make-phyloseq-object.R
@@ -66,6 +66,27 @@ colnames(tax_table(ps)) <- c("Domain_Kingdom", "Phylum", "Class", "Order", "Fami
 if (taxlength == "7"){
 colnames(tax_table(ps)) <- c("Domain_Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")
 }
+
+# Replacing NAs in taxonomy table with the best available classification:
+# extracting taxonomy table from the phyloseq object
+ps.tax <- tax_table(ps)
+
+# vector for abbreviations of taxonomic levels
+taxabb <- c("ki", "ph", "cl", "or", "fa", "ge")
+
+# for loop for replacing NAs
+# when an entry does not have an NA, it is saved as tmptax
+# if the next entry is NA, the previous tmptax is used in paste
+
+for(i in 1:nrow(ps.tax)) {
+  for(j in 1:ncol(ps.tax)) {
+    if(is.na(ps.tax[i,j]) == TRUE) { ps.tax[i,j] <- paste(tmptax,taxabb[j],sep="_")}
+    else { tmptax <- ps.tax[i,j]}
+  }
+}
+# returning the modified taxonomy table to the phyloseq object
+tax_table(ps) <- ps.tax
+
 # take out the sample names
 samples.out <- sample_names(ps) 
 # write phenodata.tsv


### PR DESCRIPTION
The combination of DADA2 and Silva 138.1 creates NAs in the taxonomy table at taxonomic levels where the ASV has no classification. Other phyloseq commands such as subset_taxa (used in metabarcoding-filter-individual.R) remove ASVs with NAs. To prevent the removal of these ASVs, this fix changes NAs to for example 'WPS-2_cl' (the lowest available taxonomic classification + abbreviation of the current taxonomic level). Taken and modified from https://mothur.org/blog/2021/SILVA-v138_1-reference-files/