### PR TITLE
Correct chloroplast tax level

### DIFF
--- a/tools/ngs/R/metabarcoding-filter-individual.R
+++ b/tools/ngs/R/metabarcoding-filter-individual.R
@@ -2,7 +2,7 @@
 # INPUT ps.Rda: "Phyloseq object in .Rda format" TYPE GENERIC
 # OUTPUT ps_ind.Rda
 # OUTPUT ps_ind_taxon.txt
-# PARAMETER OPTIONAL remove.chloroplast: "Remove class Chloroplast" TYPE [yes, no] DEFAULT yes (Remove class Chloroplast)
+# PARAMETER OPTIONAL remove.chloroplast: "Remove order Chloroplast" TYPE [yes, no] DEFAULT yes (Remove order Chloroplast)
 # PARAMETER OPTIONAL remove.mitochondria: "Remove family Mitochondria" TYPE [yes, no] DEFAULT yes (Remove family Mitochondria)
 # PARAMETER OPTIONAL type: "Level of biological organization for manual taxon removal" TYPE [phylum: "Phylum", class: "Class", order: "Order", family: "Family", genus: "Genus", species: "Species"] DEFAULT phylum (Select the desired taxonomic level; default is phylum)
 # PARAMETER OPTIONAL tax1: "Taxon to be removed" TYPE STRING (Name of taxon to be filtered out)


### PR DESCRIPTION
Change in parameter menu text of the tool "Remove selected taxa": Text said "Remove class Chloroplast" when it should say "Remove order Chloroplast" (the taxonomy level changed in Silva while ago). The actual script is correct.